### PR TITLE
build against 2022.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ plugins {
     id 'org.jetbrains.intellij' version '0.7.2'
 }
 
-def ideBaseVersion = "2021.2"
-def ideFullVersion = "${ideBaseVersion}.3"
+def ideBaseVersion = "2022.1"
+def ideFullVersion = "${ideBaseVersion}.1"
 
 group 'com.github.mutcianm'
 version "${ideBaseVersion}.1"
@@ -18,10 +18,10 @@ dependencies {
 }
 
 intellij {
-    version "212.5080.55"
+    version "221.5080.210"
     patchPluginXml {
-        sinceBuild "211.0"
-        untilBuild "213.*"
+        sinceBuild "221.0"
+        untilBuild "222.*"
     }
 }
 

--- a/src/main/java/com/github/mutcianm/lafswitch/LafChangeListener.java
+++ b/src/main/java/com/github/mutcianm/lafswitch/LafChangeListener.java
@@ -2,8 +2,6 @@ package com.github.mutcianm.lafswitch;
 
 import com.intellij.ide.AppLifecycleListener;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.project.Project;
-import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 
@@ -12,7 +10,7 @@ class LafChangeListener implements AppLifecycleListener {
     private final Logger LOG = Logger.getInstance(LafChangeListener.class);
 
     @Override
-    public void appStarting(@Nullable Project projectFromCommandLine) {
+    public void appStarted() {
         try {
             LafSwitchService.getInstance().restartSocket();
         } catch (IOException e) {


### PR DESCRIPTION
I am not familiar with Intellij versioning or the application lifecycle but this change makes the plugin compatible with IJ 2022.1